### PR TITLE
Fix token limit handling in chat

### DIFF
--- a/components/utils/constants.ts
+++ b/components/utils/constants.ts
@@ -12,7 +12,10 @@ Respond in beautiful looking markdown. Give Options. Allow them to fail. Do not 
 
 export const presets = {
   temperature: 0.6,
-  max_tokens: 517,
+  // Limit the response length so the client doesn't receive more
+  // tokens than it can handle. "maxTokens" is the expected option
+  // name for the AI SDK; using "max_tokens" would be ignored.
+  maxTokens: 517,
   top_p: 1,
   frequency_penalty: 0,
   presence_penalty: 0,


### PR DESCRIPTION
## Summary
- ensure the AI SDK uses `maxTokens` so responses don't exceed the client limit

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869365b789c83238acf59a7dfd116ac